### PR TITLE
Docker volumes for DB backups and clickhouse server logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     image: postgres:13
     restart: always
     volumes:
-      - db-data:/var/lib/postgresql/data
-      - ./backup:/backup
+      - db-data:/var/lib/postgresql/data/
+      - db-backup:/backup/
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=plausible
@@ -21,7 +21,8 @@ services:
     image: clickhouse/clickhouse-server:22.6-alpine
     restart: always
     volumes:
-      - event-data:/var/lib/clickhouse
+      - event-data:/var/lib/clickhouse/
+      - event-server-logs:/var/log/clickhouse-server/
       - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro
       - ./clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/logging.xml:ro
     ulimits:
@@ -48,7 +49,11 @@ services:
 volumes:
   db-data:
     driver: local
+  db-backup:
+    driver: local
   event-data:
+    driver: local
+  event-server-logs:
     driver: local
   geoip:
     driver: local


### PR DESCRIPTION
Move `/backup/` within the PostgreSQL container to a named volume and use a named volume for the ClickHouse Server logs rather than an anonymous volume.

This should shift all storage used by Plausible to `/var/lib/docker/`. After that it would be possible to create an OpenStack block device and mount it there to fix the constant issues with the storage space.

Closes https://github.com/usegalaxy-eu/issues/issues/947.