### PR TITLE
Update ClickHouse user config for insert settings

### DIFF
--- a/clickhouse/clickhouse-user-config.xml
+++ b/clickhouse/clickhouse-user-config.xml
@@ -3,6 +3,15 @@
         <default>
             <log_queries>0</log_queries>
             <log_query_threads>0</log_query_threads>
+
+            <!-- Increase maximum parts before ClickHouse delays inserts (Default: 150) -->
+            <parts_to_delay_insert>300</parts_to_delay_insert>
+            
+            <!-- Increase maximum parts before ClickHouse blocks inserts (Default: 300) -->
+            <parts_to_throw_insert>600</parts_to_throw_insert>
+            
+            <background_pool_size>16</background_pool_size>     
+
         </default>
     </profiles>
 </clickhouse>


### PR DESCRIPTION
When migrating plausible and clickhouse from Openstack to KVM/libvirt, it started throwing errors like [discussed here](https://github.com/ClickHouse/ClickHouse/issues/3174) after adding these lines (suggested by AI and similar to those in the discussion), the errors stopped.

part of:
- https://github.com/usegalaxy-eu/issues/issues/630